### PR TITLE
Set a default OpenCL version to shut up the library

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -3,7 +3,7 @@
 ## This file is processed by configure to generate Makevars
 ## It includes GPU backend configuration (OpenCL, CUDA) and other settings
 
-PKG_CPPFLAGS = -I../inst/include
+PKG_CPPFLAGS = -I../inst/include -DCL_TARGET_OPENCL_VERSION=300
 
 ## Compiler flags from configure
 PKG_CXXFLAGS = @BANDICOOT_CXXFLAGS@ @OPENMP_CXXFLAGS@


### PR DESCRIPTION
This one is more borderline, and @rcurtin already provided sage advice ... but without it the damn build is very very noisy.

I would understand if you said 'cannot pick a version' and close this.  