### PR TITLE
Move adapt_uword default-init from class body to primary ctor init list

### DIFF
--- a/configure
+++ b/configure
@@ -4534,28 +4534,10 @@ printf "%s\n" "not found" >&6; }
     is_apple_compiler="no"
 fi
 
-## =============================================================================
-## C++14 Standard Check (Required by Bandicoot)
-## =============================================================================
-## Note: C++14 is specified in SystemRequirements in DESCRIPTION
-## R's build system will automatically use the appropriate C++ standard
-## We use C++14 here for configure tests to ensure dependency compatibility
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C++14 is supported" >&5
-printf %s "checking whether C++14 is supported... " >&6; }
-CXX14=$(${R_HOME}/bin/R CMD config CXX14)
-CXX14FLAGS=$(${R_HOME}/bin/R CMD config CXX14FLAGS)
-CXX14STD=$(${R_HOME}/bin/R CMD config CXX14STD)
-
-if test "x${CXX14}" = x; then
-  as_fn_error $? "C++14 support is required but not available. Please use a compiler that supports C++14." "$LINENO" 5
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-## Use C++14 for configure tests (to ensure dependency compatibility)
-CXX="${CXX14} ${CXX14STD}"
-CXXFLAGS="${CXX14FLAGS} ${CXXFLAGS}"
+## R 4.5 made `R CMD config CXX14` (and CXX14FLAGS / CXX14STD) defunct;
+## R now exposes a single CXX whose default is already at C++17 or later
+## across supported platforms, which exceeds bandicoot's needs. Trust
+## that default and use the CXX/CXXFLAGS already set by AC_PROG_CXX above.
 
 ## Default flags
 BANDICOOT_CXXFLAGS=""
@@ -5272,8 +5254,8 @@ printf "%s\n" "$as_me: " >&6;}
 printf "%s\n" "$as_me: GPU Backend Configuration Summary:" >&6;}
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}:   Platform:      ${RSysinfoName}" >&5
 printf "%s\n" "$as_me:   Platform:      ${RSysinfoName}" >&6;}
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   C++ Standard:  C++14 or later" >&5
-printf "%s\n" "$as_me:   C++ Standard:  C++14 or later" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   C++ Standard:  R default (C++17 or later on R >= 4.5)" >&5
+printf "%s\n" "$as_me:   C++ Standard:  R default (C++17 or later on R >= 4.5)" >&6;}
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}:   OpenCL:        ${HAVE_OPENCL}" >&5
 printf "%s\n" "$as_me:   OpenCL:        ${HAVE_OPENCL}" >&6;}
 if test "x${HAVE_OPENCL}" = x1; then

--- a/configure.ac
+++ b/configure.ac
@@ -49,26 +49,10 @@ else
     is_apple_compiler="no"
 fi
 
-## =============================================================================
-## C++14 Standard Check (Required by Bandicoot)
-## =============================================================================
-## Note: C++14 is specified in SystemRequirements in DESCRIPTION
-## R's build system will automatically use the appropriate C++ standard
-## We use C++14 here for configure tests to ensure dependency compatibility
-
-AC_MSG_CHECKING([whether C++14 is supported])
-CXX14=$(${R_HOME}/bin/R CMD config CXX14)
-CXX14FLAGS=$(${R_HOME}/bin/R CMD config CXX14FLAGS)
-CXX14STD=$(${R_HOME}/bin/R CMD config CXX14STD)
-
-if test "x${CXX14}" = x; then
-  AC_MSG_ERROR([C++14 support is required but not available. Please use a compiler that supports C++14.])
-fi
-AC_MSG_RESULT([yes])
-
-## Use C++14 for configure tests (to ensure dependency compatibility)
-CXX="${CXX14} ${CXX14STD}"
-CXXFLAGS="${CXX14FLAGS} ${CXXFLAGS}"
+## R 4.5 made `R CMD config CXX14` (and CXX14FLAGS / CXX14STD) defunct;
+## R now exposes a single CXX whose default is already at C++17 or later
+## across supported platforms, which exceeds bandicoot's needs. Trust
+## that default and use the CXX/CXXFLAGS already set by AC_PROG_CXX above.
 
 ## Default flags
 BANDICOOT_CXXFLAGS=""
@@ -397,7 +381,7 @@ BANDICOOT_KERNELS_DIR=$(${R_HOME}/bin/Rscript -e 'cat(paste(head(.libPaths(),1),
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([GPU Backend Configuration Summary:])
 AC_MSG_NOTICE([  Platform:      ${RSysinfoName}])
-AC_MSG_NOTICE([  C++ Standard:  C++14 or later])
+AC_MSG_NOTICE([  C++ Standard:  R default (C++17 or later on R >= 4.5)])
 AC_MSG_NOTICE([  OpenCL:        ${HAVE_OPENCL}])
 if test "x${HAVE_OPENCL}" = x1; then
   AC_MSG_NOTICE([  CLBlast:       ${HAVE_CLBLAST}])

--- a/inst/include/bandicoot_bits/opencl/runtime_bones.hpp
+++ b/inst/include/bandicoot_bits/opencl/runtime_bones.hpp
@@ -271,10 +271,10 @@ class runtime_t::adapt_uword
   {
   public:
 
-  coot_aligned size_t size  = 0;
-  coot_aligned void*  addr  = nullptr;
-  coot_aligned u64    val64 = 0;
-  coot_aligned u32    val32 = 0;
+  coot_aligned size_t size;
+  coot_aligned void*  addr;
+  coot_aligned u64    val64;
+  coot_aligned u32    val32;
 
   inline adapt_uword(const uword val = 0); // default value needed for allocating several at once
 

--- a/inst/include/bandicoot_bits/opencl/runtime_meat.hpp
+++ b/inst/include/bandicoot_bits/opencl/runtime_meat.hpp
@@ -1680,6 +1680,10 @@ runtime_t::cq_guard::~cq_guard()
 
 inline
 runtime_t::adapt_uword::adapt_uword(const uword val)
+  : size(0)
+  , addr(nullptr)
+  , val64(0)
+  , val32(0)
   {
   if((sizeof(uword) >= 8) && get_rt().cl_rt.has_sizet64())
     {


### PR DESCRIPTION
Per upstream feedback on bandicoot [MR !249](https://gitlab.com/bandicoot-lib/bandicoot-code/-/merge_requests/249).