### PR TITLE
DEMO (do not merge): prove the ad-hoc OpenCL CI never tests the runtime

### DIFF
--- a/man/gpu_matrix_multiply.Rd
+++ b/man/gpu_matrix_multiply.Rd
@@ -17,3 +17,11 @@ Product of A and B computed on GPU
 \description{
 Multiply two matrices on the GPU using Bandicoot
 }
+\examples{
+# This example runs during R CMD check. It executes a real OpenCL kernel,
+# so it only passes on a runner that has a working OpenCL device. The
+# ad-hoc CI setup on this branch never provided one, which is exactly what
+# this example is here to demonstrate.
+A <- matrix(c(1, 2, 3, 4), 2, 2)
+gpu_matrix_multiply(A, A)
+}

--- a/src/gpu-ops.cpp
+++ b/src/gpu-ops.cpp
@@ -7,6 +7,13 @@
 //' @param A First matrix
 //' @param B Second matrix
 //' @return Product of A and B computed on GPU
+//' @examples
+//' # This example runs during R CMD check. It executes a real OpenCL kernel,
+//' # so it only passes on a runner that has a working OpenCL device. The
+//' # ad-hoc CI setup on this branch never provided one, which is exactly what
+//' # this example is here to demonstrate.
+//' A <- matrix(c(1, 2, 3, 4), 2, 2)
+//' gpu_matrix_multiply(A, A)
 //' @export
 // [[Rcpp::export]]
 coot::fmat gpu_matrix_multiply(const coot::fmat& A, const coot::fmat& B) {


### PR DESCRIPTION
**This PR is a demonstrator, not for merge.**

It branches from the pre-migration `main` (the old ad-hoc OpenCL/CLBlast CI setup, unchanged) and adds exactly one thing: a runnable `\examples` block on `gpu_matrix_multiply` that executes a real OpenCL kernel during `R CMD check`.

**Hypothesis:** the old CI is green only because nothing in `R CMD check` ever runs a kernel — no tests, no vignettes, no runnable GPU examples. The elaborate OpenCL provisioning in the workflow is load-bearing for nothing.

**Prediction:** with one example that actually runs a kernel, all three legs go **red**, each for its own reason:
- **Ubuntu**: `apt-get install opencl-headers ocl-icd-opencl-dev libclblast-dev` installs the loader but no ICD → zero devices.
- **Windows**: registers Intel's copy of the *loader* (`OpenCL.dll`) as an ICD vendor → the Khronos loader finds no `clIcdGetPlatformIDsKHR` and silently skips it → zero devices.
- **macOS**: Apple's `OpenCL.framework` enumerates zero devices on the virtualized runner.

Same package code that the modernized `setup-opencl`/`setup-clblast` actions run green on Linux (see the migration PR). The contrast is the point.